### PR TITLE
AST changes

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -645,10 +645,9 @@ type_params[asdl_typeparam_seq*]: '[' t=type_param_seq  ']' { t }
 type_param_seq[asdl_typeparam_seq*]: a[asdl_typeparam_seq*]=','.type_param+ [','] { a }
 
 type_param[typeparam_ty] (memo):
-    | a=NAME b=[type_param_bound] { _PyAST_TypeVar(
-        CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA) }
-    | '*' a=NAME { _PyAST_TypeVarTuple(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), EXTRA) }
-    | '**' a=NAME { _PyAST_ParamSpec(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), EXTRA) }
+    | a=NAME b=[type_param_bound] { _PyAST_TypeVar(a->v.Name.id, b, EXTRA) }
+    | '*' a=NAME { _PyAST_TypeVarTuple(a->v.Name.id, EXTRA) }
+    | '**' a=NAME { _PyAST_ParamSpec(a->v.Name.id, EXTRA) }
 
 type_param_bound[expr_ty]: ":" e=expression { e }
 

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -645,9 +645,10 @@ type_params[asdl_typeparam_seq*]: '[' t=type_param_seq  ']' { t }
 type_param_seq[asdl_typeparam_seq*]: a[asdl_typeparam_seq*]=','.type_param+ [','] { a }
 
 type_param[typeparam_ty] (memo):
-    | a=NAME b=[type_param_bound] { _PyAST_TypeVar(a->v.Name.id, b, EXTRA) }
-    | '*' a=NAME { _PyAST_TypeVarTuple(a->v.Name.id, EXTRA) }
-    | '**' a=NAME { _PyAST_ParamSpec(a->v.Name.id, EXTRA) }
+    | a=NAME b=[type_param_bound] { _PyAST_TypeVar(
+        CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA) }
+    | '*' a=NAME { _PyAST_TypeVarTuple(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), EXTRA) }
+    | '**' a=NAME { _PyAST_ParamSpec(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), EXTRA) }
 
 type_param_bound[expr_ty]: ":" e=expression { e }
 

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -634,7 +634,8 @@ keyword_pattern[KeyPatternPair*]:
 
 type_alias[stmt_ty]:
     | "type" n=NAME t=[type_params] '=' b=expression {
-        CHECK_VERSION(stmt_ty, 12, "Type statement is", _PyAST_TypeAlias(n->v.Name.id, t, b, EXTRA)) }
+        CHECK_VERSION(stmt_ty, 12, "Type statement is",
+        _PyAST_TypeAlias(CHECK(expr_ty, _PyPegen_set_expr_context(p, n, Store)), t, b, EXTRA)) }
 
 # Type parameter declaration
 # --------------------------

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -239,7 +239,7 @@ struct _stmt {
         } Assign;
 
         struct {
-            identifier name;
+            expr_ty name;
             asdl_typeparam_seq *typeparams;
             expr_ty value;
         } TypeAlias;
@@ -704,9 +704,9 @@ stmt_ty _PyAST_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int
 stmt_ty _PyAST_Assign(asdl_expr_seq * targets, expr_ty value, string
                       type_comment, int lineno, int col_offset, int end_lineno,
                       int end_col_offset, PyArena *arena);
-stmt_ty _PyAST_TypeAlias(identifier name, asdl_typeparam_seq * typeparams,
-                         expr_ty value, int lineno, int col_offset, int
-                         end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_TypeAlias(expr_ty name, asdl_typeparam_seq * typeparams, expr_ty
+                         value, int lineno, int col_offset, int end_lineno, int
+                         end_col_offset, PyArena *arena);
 stmt_ty _PyAST_AugAssign(expr_ty target, operator_ty op, expr_ty value, int
                          lineno, int col_offset, int end_lineno, int
                          end_col_offset, PyArena *arena);

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -654,16 +654,16 @@ struct _typeparam {
     enum _typeparam_kind kind;
     union {
         struct {
-            identifier name;
+            expr_ty name;
             expr_ty bound;
         } TypeVar;
 
         struct {
-            identifier name;
+            expr_ty name;
         } ParamSpec;
 
         struct {
-            identifier name;
+            expr_ty name;
         } TypeVarTuple;
 
     } v;
@@ -891,13 +891,13 @@ pattern_ty _PyAST_MatchOr(asdl_pattern_seq * patterns, int lineno, int
                           col_offset, int end_lineno, int end_col_offset,
                           PyArena *arena);
 type_ignore_ty _PyAST_TypeIgnore(int lineno, string tag, PyArena *arena);
-typeparam_ty _PyAST_TypeVar(identifier name, expr_ty bound, int lineno, int
+typeparam_ty _PyAST_TypeVar(expr_ty name, expr_ty bound, int lineno, int
                             col_offset, int end_lineno, int end_col_offset,
                             PyArena *arena);
-typeparam_ty _PyAST_ParamSpec(identifier name, int lineno, int col_offset, int
+typeparam_ty _PyAST_ParamSpec(expr_ty name, int lineno, int col_offset, int
                               end_lineno, int end_col_offset, PyArena *arena);
-typeparam_ty _PyAST_TypeVarTuple(identifier name, int lineno, int col_offset,
-                                 int end_lineno, int end_col_offset, PyArena
+typeparam_ty _PyAST_TypeVarTuple(expr_ty name, int lineno, int col_offset, int
+                                 end_lineno, int end_col_offset, PyArena
                                  *arena);
 
 

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -654,16 +654,16 @@ struct _typeparam {
     enum _typeparam_kind kind;
     union {
         struct {
-            expr_ty name;
+            identifier name;
             expr_ty bound;
         } TypeVar;
 
         struct {
-            expr_ty name;
+            identifier name;
         } ParamSpec;
 
         struct {
-            expr_ty name;
+            identifier name;
         } TypeVarTuple;
 
     } v;
@@ -891,13 +891,13 @@ pattern_ty _PyAST_MatchOr(asdl_pattern_seq * patterns, int lineno, int
                           col_offset, int end_lineno, int end_col_offset,
                           PyArena *arena);
 type_ignore_ty _PyAST_TypeIgnore(int lineno, string tag, PyArena *arena);
-typeparam_ty _PyAST_TypeVar(expr_ty name, expr_ty bound, int lineno, int
+typeparam_ty _PyAST_TypeVar(identifier name, expr_ty bound, int lineno, int
                             col_offset, int end_lineno, int end_col_offset,
                             PyArena *arena);
-typeparam_ty _PyAST_ParamSpec(expr_ty name, int lineno, int col_offset, int
+typeparam_ty _PyAST_ParamSpec(identifier name, int lineno, int col_offset, int
                               end_lineno, int end_col_offset, PyArena *arena);
-typeparam_ty _PyAST_TypeVarTuple(expr_ty name, int lineno, int col_offset, int
-                                 end_lineno, int end_col_offset, PyArena
+typeparam_ty _PyAST_TypeVarTuple(identifier name, int lineno, int col_offset,
+                                 int end_lineno, int end_col_offset, PyArena
                                  *arena);
 
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1058,18 +1058,16 @@ class _Unparser(NodeVisitor):
                 self.interleave(lambda: self.write(", "), self.traverse, typeparams)
 
     def visit_TypeVar(self, node):
-        self.traverse(node.name)
+        self.write(node.name)
         if node.bound:
             self.write(": ")
             self.traverse(node.bound)
 
     def visit_TypeVarTuple(self, node):
-        self.write("*")
-        self.traverse(node.name)
+        self.write("*" + node.name)
 
     def visit_ParamSpec(self, node):
-        self.write("**")
-        self.traverse(node.name)
+        self.write("**" + node.name)
 
     def visit_TypeAlias(self, node):
         self.fill("type ")

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1070,7 +1070,8 @@ class _Unparser(NodeVisitor):
         self.write("**" + node.name)
 
     def visit_TypeAlias(self, node):
-        self.fill("type " + node.name)
+        self.fill("type ")
+        self.traverse(node.name)
         self._typeparams_helper(node.typeparams)
         self.write(" = ")
         self.traverse(node.value)

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1058,16 +1058,18 @@ class _Unparser(NodeVisitor):
                 self.interleave(lambda: self.write(", "), self.traverse, typeparams)
 
     def visit_TypeVar(self, node):
-        self.write(node.name)
+        self.traverse(node.name)
         if node.bound:
             self.write(": ")
             self.traverse(node.bound)
 
     def visit_TypeVarTuple(self, node):
-        self.write("*" + node.name)
+        self.write("*")
+        self.traverse(node.name)
 
     def visit_ParamSpec(self, node):
-        self.write("**" + node.name)
+        self.write("**")
+        self.traverse(node.name)
 
     def visit_TypeAlias(self, node):
         self.fill("type ")

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -145,8 +145,8 @@ module Python
 
     type_ignore = TypeIgnore(int lineno, string tag)
 
-    typeparam = TypeVar(expr name, expr? bound)
-            | ParamSpec(expr name)
-            | TypeVarTuple(expr name)
+    typeparam = TypeVar(identifier name, expr? bound)
+            | ParamSpec(identifier name)
+            | TypeVarTuple(identifier name)
              attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 }

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -145,8 +145,8 @@ module Python
 
     type_ignore = TypeIgnore(int lineno, string tag)
 
-    typeparam = TypeVar(identifier name, expr? bound)
-            | ParamSpec(identifier name)
-            | TypeVarTuple(identifier name)
+    typeparam = TypeVar(expr name, expr? bound)
+            | ParamSpec(expr name)
+            | TypeVarTuple(expr name)
              attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 }

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -25,7 +25,7 @@ module Python
 
           | Delete(expr* targets)
           | Assign(expr* targets, expr value, string? type_comment)
-          | TypeAlias(identifier name, typeparam* typeparams, expr value)
+          | TypeAlias(expr name, typeparam* typeparams, expr value)
           | AugAssign(expr target, operator op, expr value)
           -- 'simple' indicates that we annotate simple name without parens
           | AnnAssign(expr target, expr annotation, expr? value, int simple)

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -10563,7 +10563,7 @@ type_alias_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 12 , "Type statement is" , _PyAST_TypeAlias ( n -> v . Name . id , t , b , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 12 , "Type statement is" , _PyAST_TypeAlias ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , n , Store ) ) , t , b , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -10730,7 +10730,7 @@ type_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_TypeVar ( a -> v . Name . id , b , EXTRA );
+            _res = _PyAST_TypeVar ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -10766,7 +10766,7 @@ type_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_TypeVarTuple ( a -> v . Name . id , EXTRA );
+            _res = _PyAST_TypeVarTuple ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -10802,7 +10802,7 @@ type_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_ParamSpec ( a -> v . Name . id , EXTRA );
+            _res = _PyAST_ParamSpec ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -10730,7 +10730,7 @@ type_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_TypeVar ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA );
+            _res = _PyAST_TypeVar ( a -> v . Name . id , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -10766,7 +10766,7 @@ type_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_TypeVarTuple ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , EXTRA );
+            _res = _PyAST_TypeVarTuple ( a -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -10802,7 +10802,7 @@ type_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyAST_ParamSpec ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , EXTRA );
+            _res = _PyAST_ParamSpec ( a -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1896,9 +1896,9 @@ init_types(struct ast_state *state)
     if (!state->TypeIgnore_type) return 0;
     state->typeparam_type = make_type(state, "typeparam", state->AST_type,
                                       NULL, 0,
-        "typeparam = TypeVar(expr name, expr? bound)\n"
-        "          | ParamSpec(expr name)\n"
-        "          | TypeVarTuple(expr name)");
+        "typeparam = TypeVar(identifier name, expr? bound)\n"
+        "          | ParamSpec(identifier name)\n"
+        "          | TypeVarTuple(identifier name)");
     if (!state->typeparam_type) return 0;
     if (!add_attributes(state, state->typeparam_type, typeparam_attributes, 4))
         return 0;
@@ -1910,19 +1910,19 @@ init_types(struct ast_state *state)
         return 0;
     state->TypeVar_type = make_type(state, "TypeVar", state->typeparam_type,
                                     TypeVar_fields, 2,
-        "TypeVar(expr name, expr? bound)");
+        "TypeVar(identifier name, expr? bound)");
     if (!state->TypeVar_type) return 0;
     if (PyObject_SetAttr(state->TypeVar_type, state->bound, Py_None) == -1)
         return 0;
     state->ParamSpec_type = make_type(state, "ParamSpec",
                                       state->typeparam_type, ParamSpec_fields,
                                       1,
-        "ParamSpec(expr name)");
+        "ParamSpec(identifier name)");
     if (!state->ParamSpec_type) return 0;
     state->TypeVarTuple_type = make_type(state, "TypeVarTuple",
                                          state->typeparam_type,
                                          TypeVarTuple_fields, 1,
-        "TypeVarTuple(expr name)");
+        "TypeVarTuple(identifier name)");
     if (!state->TypeVarTuple_type) return 0;
 
     state->recursion_depth = 0;
@@ -3714,7 +3714,7 @@ _PyAST_TypeIgnore(int lineno, string tag, PyArena *arena)
 }
 
 typeparam_ty
-_PyAST_TypeVar(expr_ty name, expr_ty bound, int lineno, int col_offset, int
+_PyAST_TypeVar(identifier name, expr_ty bound, int lineno, int col_offset, int
                end_lineno, int end_col_offset, PyArena *arena)
 {
     typeparam_ty p;
@@ -3737,8 +3737,8 @@ _PyAST_TypeVar(expr_ty name, expr_ty bound, int lineno, int col_offset, int
 }
 
 typeparam_ty
-_PyAST_ParamSpec(expr_ty name, int lineno, int col_offset, int end_lineno, int
-                 end_col_offset, PyArena *arena)
+_PyAST_ParamSpec(identifier name, int lineno, int col_offset, int end_lineno,
+                 int end_col_offset, PyArena *arena)
 {
     typeparam_ty p;
     if (!name) {
@@ -3759,8 +3759,8 @@ _PyAST_ParamSpec(expr_ty name, int lineno, int col_offset, int end_lineno, int
 }
 
 typeparam_ty
-_PyAST_TypeVarTuple(expr_ty name, int lineno, int col_offset, int end_lineno,
-                    int end_col_offset, PyArena *arena)
+_PyAST_TypeVarTuple(identifier name, int lineno, int col_offset, int
+                    end_lineno, int end_col_offset, PyArena *arena)
 {
     typeparam_ty p;
     if (!name) {
@@ -5674,7 +5674,7 @@ ast2obj_typeparam(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeVar_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.TypeVar.name);
+        value = ast2obj_identifier(state, o->v.TypeVar.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -5689,7 +5689,7 @@ ast2obj_typeparam(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ParamSpec_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.ParamSpec.name);
+        value = ast2obj_identifier(state, o->v.ParamSpec.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -5699,7 +5699,7 @@ ast2obj_typeparam(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeVarTuple_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.TypeVarTuple.name);
+        value = ast2obj_identifier(state, o->v.TypeVarTuple.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -12383,7 +12383,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
         return 1;
     }
     if (isinstance) {
-        expr_ty name;
+        identifier name;
         expr_ty bound;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
@@ -12398,7 +12398,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
             if (_Py_EnterRecursiveCall(" while traversing 'TypeVar' node")) {
                 goto failed;
             }
-            res = obj2ast_expr(state, tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
@@ -12431,7 +12431,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
         return 1;
     }
     if (isinstance) {
-        expr_ty name;
+        identifier name;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
@@ -12445,7 +12445,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
             if (_Py_EnterRecursiveCall(" while traversing 'ParamSpec' node")) {
                 goto failed;
             }
-            res = obj2ast_expr(state, tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
@@ -12461,7 +12461,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
         return 1;
     }
     if (isinstance) {
-        expr_ty name;
+        identifier name;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
@@ -12475,7 +12475,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
             if (_Py_EnterRecursiveCall(" while traversing 'TypeVarTuple' node")) {
                 goto failed;
             }
-            res = obj2ast_expr(state, tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1175,7 +1175,7 @@ init_types(struct ast_state *state)
         "     | Return(expr? value)\n"
         "     | Delete(expr* targets)\n"
         "     | Assign(expr* targets, expr value, string? type_comment)\n"
-        "     | TypeAlias(identifier name, typeparam* typeparams, expr value)\n"
+        "     | TypeAlias(expr name, typeparam* typeparams, expr value)\n"
         "     | AugAssign(expr target, operator op, expr value)\n"
         "     | AnnAssign(expr target, expr annotation, expr? value, int simple)\n"
         "     | For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)\n"
@@ -1248,7 +1248,7 @@ init_types(struct ast_state *state)
         return 0;
     state->TypeAlias_type = make_type(state, "TypeAlias", state->stmt_type,
                                       TypeAlias_fields, 3,
-        "TypeAlias(identifier name, typeparam* typeparams, expr value)");
+        "TypeAlias(expr name, typeparam* typeparams, expr value)");
     if (!state->TypeAlias_type) return 0;
     state->AugAssign_type = make_type(state, "AugAssign", state->stmt_type,
                                       AugAssign_fields, 3,
@@ -2192,8 +2192,8 @@ _PyAST_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment, int
 }
 
 stmt_ty
-_PyAST_TypeAlias(identifier name, asdl_typeparam_seq * typeparams, expr_ty
-                 value, int lineno, int col_offset, int end_lineno, int
+_PyAST_TypeAlias(expr_ty name, asdl_typeparam_seq * typeparams, expr_ty value,
+                 int lineno, int col_offset, int end_lineno, int
                  end_col_offset, PyArena *arena)
 {
     stmt_ty p;
@@ -4047,7 +4047,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeAlias_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.TypeAlias.name);
+        value = ast2obj_expr(state, o->v.TypeAlias.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -6846,7 +6846,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         return 1;
     }
     if (isinstance) {
-        identifier name;
+        expr_ty name;
         asdl_typeparam_seq* typeparams;
         expr_ty value;
 
@@ -6862,7 +6862,7 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (_Py_EnterRecursiveCall(" while traversing 'TypeAlias' node")) {
                 goto failed;
             }
-            res = obj2ast_identifier(state, tmp, &name, arena);
+            res = obj2ast_expr(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1896,9 +1896,9 @@ init_types(struct ast_state *state)
     if (!state->TypeIgnore_type) return 0;
     state->typeparam_type = make_type(state, "typeparam", state->AST_type,
                                       NULL, 0,
-        "typeparam = TypeVar(identifier name, expr? bound)\n"
-        "          | ParamSpec(identifier name)\n"
-        "          | TypeVarTuple(identifier name)");
+        "typeparam = TypeVar(expr name, expr? bound)\n"
+        "          | ParamSpec(expr name)\n"
+        "          | TypeVarTuple(expr name)");
     if (!state->typeparam_type) return 0;
     if (!add_attributes(state, state->typeparam_type, typeparam_attributes, 4))
         return 0;
@@ -1910,19 +1910,19 @@ init_types(struct ast_state *state)
         return 0;
     state->TypeVar_type = make_type(state, "TypeVar", state->typeparam_type,
                                     TypeVar_fields, 2,
-        "TypeVar(identifier name, expr? bound)");
+        "TypeVar(expr name, expr? bound)");
     if (!state->TypeVar_type) return 0;
     if (PyObject_SetAttr(state->TypeVar_type, state->bound, Py_None) == -1)
         return 0;
     state->ParamSpec_type = make_type(state, "ParamSpec",
                                       state->typeparam_type, ParamSpec_fields,
                                       1,
-        "ParamSpec(identifier name)");
+        "ParamSpec(expr name)");
     if (!state->ParamSpec_type) return 0;
     state->TypeVarTuple_type = make_type(state, "TypeVarTuple",
                                          state->typeparam_type,
                                          TypeVarTuple_fields, 1,
-        "TypeVarTuple(identifier name)");
+        "TypeVarTuple(expr name)");
     if (!state->TypeVarTuple_type) return 0;
 
     state->recursion_depth = 0;
@@ -3714,7 +3714,7 @@ _PyAST_TypeIgnore(int lineno, string tag, PyArena *arena)
 }
 
 typeparam_ty
-_PyAST_TypeVar(identifier name, expr_ty bound, int lineno, int col_offset, int
+_PyAST_TypeVar(expr_ty name, expr_ty bound, int lineno, int col_offset, int
                end_lineno, int end_col_offset, PyArena *arena)
 {
     typeparam_ty p;
@@ -3737,8 +3737,8 @@ _PyAST_TypeVar(identifier name, expr_ty bound, int lineno, int col_offset, int
 }
 
 typeparam_ty
-_PyAST_ParamSpec(identifier name, int lineno, int col_offset, int end_lineno,
-                 int end_col_offset, PyArena *arena)
+_PyAST_ParamSpec(expr_ty name, int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena)
 {
     typeparam_ty p;
     if (!name) {
@@ -3759,8 +3759,8 @@ _PyAST_ParamSpec(identifier name, int lineno, int col_offset, int end_lineno,
 }
 
 typeparam_ty
-_PyAST_TypeVarTuple(identifier name, int lineno, int col_offset, int
-                    end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_TypeVarTuple(expr_ty name, int lineno, int col_offset, int end_lineno,
+                    int end_col_offset, PyArena *arena)
 {
     typeparam_ty p;
     if (!name) {
@@ -5674,7 +5674,7 @@ ast2obj_typeparam(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeVar_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.TypeVar.name);
+        value = ast2obj_expr(state, o->v.TypeVar.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -5689,7 +5689,7 @@ ast2obj_typeparam(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ParamSpec_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.ParamSpec.name);
+        value = ast2obj_expr(state, o->v.ParamSpec.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -5699,7 +5699,7 @@ ast2obj_typeparam(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeVarTuple_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.TypeVarTuple.name);
+        value = ast2obj_expr(state, o->v.TypeVarTuple.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -12383,7 +12383,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
         return 1;
     }
     if (isinstance) {
-        identifier name;
+        expr_ty name;
         expr_ty bound;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
@@ -12398,7 +12398,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
             if (_Py_EnterRecursiveCall(" while traversing 'TypeVar' node")) {
                 goto failed;
             }
-            res = obj2ast_identifier(state, tmp, &name, arena);
+            res = obj2ast_expr(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
@@ -12431,7 +12431,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
         return 1;
     }
     if (isinstance) {
-        identifier name;
+        expr_ty name;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
@@ -12445,7 +12445,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
             if (_Py_EnterRecursiveCall(" while traversing 'ParamSpec' node")) {
                 goto failed;
             }
-            res = obj2ast_identifier(state, tmp, &name, arena);
+            res = obj2ast_expr(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
@@ -12461,7 +12461,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
         return 1;
     }
     if (isinstance) {
-        identifier name;
+        expr_ty name;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
@@ -12475,7 +12475,7 @@ obj2ast_typeparam(struct ast_state *state, PyObject* obj, typeparam_ty* out,
             if (_Py_EnterRecursiveCall(" while traversing 'TypeVarTuple' node")) {
                 goto failed;
             }
-            res = obj2ast_identifier(state, tmp, &name, arena);
+            res = obj2ast_expr(state, tmp, &name, arena);
             _Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -681,15 +681,15 @@ validate_typeparam(struct validator *state, typeparam_ty tp)
     int ret = -1;
     switch (tp->kind) {
         case TypeVar_kind:
-            ret = validate_expr(state, tp->v.TypeVar.name, Store) &&
+            ret = validate_name(tp->v.TypeVar.name) &&
                 (!tp->v.TypeVar.bound ||
                  validate_expr(state, tp->v.TypeVar.bound, Load));
             break;
         case ParamSpec_kind:
-            ret = validate_expr(state, tp->v.ParamSpec.name, Store);
+            ret = validate_name(tp->v.ParamSpec.name);
             break;
         case TypeVarTuple_kind:
-            ret = validate_expr(state, tp->v.TypeVarTuple.name, Store);
+            ret = validate_name(tp->v.TypeVarTuple.name);
             break;
     }
     return ret;
@@ -772,7 +772,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
                validate_expr(state, stmt->v.AnnAssign.annotation, Load);
         break;
     case TypeAlias_kind:
-        ret = validate_name(stmt->v.TypeAlias.name->v.Name.id) &&
+        ret = validate_expr(state, stmt->v.TypeAlias.name, Store) &&
             validate_typeparams(state, stmt->v.TypeAlias.typeparams) &&
             validate_expr(state, stmt->v.TypeAlias.value, Load);
         break;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -17,10 +17,12 @@ struct validator {
 static int validate_stmts(struct validator *, asdl_stmt_seq *);
 static int validate_exprs(struct validator *, asdl_expr_seq *, expr_context_ty, int);
 static int validate_patterns(struct validator *, asdl_pattern_seq *, int);
+static int validate_typeparams(struct validator *, asdl_typeparam_seq *);
 static int _validate_nonempty_seq(asdl_seq *, const char *, const char *);
 static int validate_stmt(struct validator *, stmt_ty);
 static int validate_expr(struct validator *, expr_ty, expr_context_ty);
 static int validate_pattern(struct validator *, pattern_ty, int);
+static int validate_typeparam(struct validator *, typeparam_ty);
 
 #define VALIDATE_POSITIONS(node) \
     if (node->lineno > node->end_lineno) { \
@@ -673,6 +675,27 @@ validate_pattern(struct validator *state, pattern_ty p, int star_ok)
 }
 
 static int
+validate_typeparam(struct validator *state, typeparam_ty tp)
+{
+    VALIDATE_POSITIONS(tp);
+    int ret = -1;
+    switch (tp->kind) {
+        case TypeVar_kind:
+            ret = validate_expr(state, tp->v.TypeVar.name, Store) &&
+                (!tp->v.TypeVar.bound ||
+                 validate_expr(state, tp->v.TypeVar.bound, Load));
+            break;
+        case ParamSpec_kind:
+            ret = validate_expr(state, tp->v.ParamSpec.name, Store);
+            break;
+        case TypeVarTuple_kind:
+            ret = validate_expr(state, tp->v.TypeVarTuple.name, Store);
+            break;
+    }
+    return ret;
+}
+
+static int
 _validate_nonempty_seq(asdl_seq *seq, const char *what, const char *owner)
 {
     if (asdl_seq_LEN(seq))
@@ -709,6 +732,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
     switch (stmt->kind) {
     case FunctionDef_kind:
         ret = validate_body(state, stmt->v.FunctionDef.body, "FunctionDef") &&
+            validate_typeparams(state, stmt->v.FunctionDef.typeparams) &&
             validate_arguments(state, stmt->v.FunctionDef.args) &&
             validate_exprs(state, stmt->v.FunctionDef.decorator_list, Load, 0) &&
             (!stmt->v.FunctionDef.returns ||
@@ -716,6 +740,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
         break;
     case ClassDef_kind:
         ret = validate_body(state, stmt->v.ClassDef.body, "ClassDef") &&
+            validate_typeparams(state, stmt->v.ClassDef.typeparams) &&
             validate_exprs(state, stmt->v.ClassDef.bases, Load, 0) &&
             validate_keywords(state, stmt->v.ClassDef.keywords) &&
             validate_exprs(state, stmt->v.ClassDef.decorator_list, Load, 0);
@@ -748,6 +773,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
         break;
     case TypeAlias_kind:
         ret = validate_name(stmt->v.TypeAlias.name->v.Name.id) &&
+            validate_typeparams(state, stmt->v.TypeAlias.typeparams) &&
             validate_expr(state, stmt->v.TypeAlias.value, Load);
         break;
     case For_kind:
@@ -897,6 +923,7 @@ validate_stmt(struct validator *state, stmt_ty stmt)
         break;
     case AsyncFunctionDef_kind:
         ret = validate_body(state, stmt->v.AsyncFunctionDef.body, "AsyncFunctionDef") &&
+            validate_typeparams(state, stmt->v.AsyncFunctionDef.typeparams) &&
             validate_arguments(state, stmt->v.AsyncFunctionDef.args) &&
             validate_exprs(state, stmt->v.AsyncFunctionDef.decorator_list, Load, 0) &&
             (!stmt->v.AsyncFunctionDef.returns ||
@@ -964,6 +991,20 @@ validate_patterns(struct validator *state, asdl_pattern_seq *patterns, int star_
         pattern_ty pattern = asdl_seq_GET(patterns, i);
         if (!validate_pattern(state, pattern, star_ok)) {
             return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+validate_typeparams(struct validator *state, asdl_typeparam_seq *tps)
+{
+    Py_ssize_t i;
+    for (i = 0; i < asdl_seq_LEN(tps); i++) {
+        typeparam_ty tp = asdl_seq_GET(tps, i);
+        if (tp) {
+            if (!validate_typeparam(state, tp))
+                return 0;
         }
     }
     return 1;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -747,7 +747,8 @@ validate_stmt(struct validator *state, stmt_ty stmt)
                validate_expr(state, stmt->v.AnnAssign.annotation, Load);
         break;
     case TypeAlias_kind:
-        ret = validate_expr(state, stmt->v.TypeAlias.value, Load);
+        ret = validate_name(stmt->v.TypeAlias.name->v.Name.id) &&
+            validate_expr(state, stmt->v.TypeAlias.value, Load);
         break;
     case For_kind:
         ret = validate_expr(state, stmt->v.For.target, Store) &&

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -1089,14 +1089,11 @@ astfold_typeparam(typeparam_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
     switch (node_->kind) {
         case TypeVar_kind:
-            CALL(astfold_expr, expr_ty, node_->v.TypeVar.name);
             CALL_OPT(astfold_expr, expr_ty, node_->v.TypeVar.bound);
             break;
         case ParamSpec_kind:
-            CALL(astfold_expr, expr_ty, node_->v.ParamSpec.name);
             break;
         case TypeVarTuple_kind:
-            CALL(astfold_expr, expr_ty, node_->v.TypeVarTuple.name);
             break;
     }
     return 1;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -882,6 +882,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     }
     switch (node_->kind) {
     case FunctionDef_kind:
+        CALL_SEQ(astfold_typeparam, typeparam, node_->v.FunctionDef.typeparams);
         CALL(astfold_arguments, arguments_ty, node_->v.FunctionDef.args);
         CALL(astfold_body, asdl_seq, node_->v.FunctionDef.body);
         CALL_SEQ(astfold_expr, expr, node_->v.FunctionDef.decorator_list);
@@ -890,6 +891,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         }
         break;
     case AsyncFunctionDef_kind:
+        CALL_SEQ(astfold_typeparam, typeparam, node_->v.AsyncFunctionDef.typeparams);
         CALL(astfold_arguments, arguments_ty, node_->v.AsyncFunctionDef.args);
         CALL(astfold_body, asdl_seq, node_->v.AsyncFunctionDef.body);
         CALL_SEQ(astfold_expr, expr, node_->v.AsyncFunctionDef.decorator_list);
@@ -898,6 +900,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         }
         break;
     case ClassDef_kind:
+        CALL_SEQ(astfold_typeparam, typeparam, node_->v.ClassDef.typeparams);
         CALL_SEQ(astfold_expr, expr, node_->v.ClassDef.bases);
         CALL_SEQ(astfold_keyword, keyword, node_->v.ClassDef.keywords);
         CALL(astfold_body, asdl_seq, node_->v.ClassDef.body);
@@ -1086,11 +1089,14 @@ astfold_typeparam(typeparam_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
     switch (node_->kind) {
         case TypeVar_kind:
+            CALL(astfold_expr, expr_ty, node_->v.TypeVar.name);
             CALL_OPT(astfold_expr, expr_ty, node_->v.TypeVar.bound);
             break;
         case ParamSpec_kind:
+            CALL(astfold_expr, expr_ty, node_->v.ParamSpec.name);
             break;
         case TypeVarTuple_kind:
+            CALL(astfold_expr, expr_ty, node_->v.TypeVarTuple.name);
             break;
     }
     return 1;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -924,6 +924,8 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         CALL_OPT(astfold_expr, expr_ty, node_->v.AnnAssign.value);
         break;
     case TypeAlias_kind:
+        CALL(astfold_expr, expr_ty, node_->v.TypeAlias.name);
+        CALL_SEQ(astfold_stmt, typeparam, node_->v.TypeAlias.typeparams);
         CALL(astfold_expr, expr_ty, node_->v.TypeAlias.value);
         break;
     case For_kind:

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -643,6 +643,7 @@ static int astfold_withitem(withitem_ty node_, PyArena *ctx_, _PyASTOptimizeStat
 static int astfold_excepthandler(excepthandler_ty node_, PyArena *ctx_, _PyASTOptimizeState *state);
 static int astfold_match_case(match_case_ty node_, PyArena *ctx_, _PyASTOptimizeState *state);
 static int astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state);
+static int astfold_typeparam(typeparam_ty node_, PyArena *ctx_, _PyASTOptimizeState *state);
 
 #define CALL(FUNC, TYPE, ARG) \
     if (!FUNC((ARG), ctx_, state)) \
@@ -925,7 +926,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         break;
     case TypeAlias_kind:
         CALL(astfold_expr, expr_ty, node_->v.TypeAlias.name);
-        CALL_SEQ(astfold_stmt, typeparam, node_->v.TypeAlias.typeparams);
+        CALL_SEQ(astfold_typeparam, typeparam, node_->v.TypeAlias.typeparams);
         CALL(astfold_expr, expr_ty, node_->v.TypeAlias.value);
         break;
     case For_kind:
@@ -1077,6 +1078,21 @@ astfold_match_case(match_case_ty node_, PyArena *ctx_, _PyASTOptimizeState *stat
     CALL(astfold_pattern, expr_ty, node_->pattern);
     CALL_OPT(astfold_expr, expr_ty, node_->guard);
     CALL_SEQ(astfold_stmt, stmt, node_->body);
+    return 1;
+}
+
+static int
+astfold_typeparam(typeparam_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
+{
+    switch (node_->kind) {
+        case TypeVar_kind:
+            CALL_OPT(astfold_expr, expr_ty, node_->v.TypeVar.bound);
+            break;
+        case ParamSpec_kind:
+            break;
+        case TypeVarTuple_kind:
+            break;
+    }
     return 1;
 }
 


### PR DESCRIPTION
The AST changes I suggested in https://discuss.python.org/t/pep-695-type-parameter-syntax/21646/99.
This stores the TypeVar / TypeAlias name as dedicated `Name(..., ctx=Store())` ast node.